### PR TITLE
Add User Access Token steps documentation. Remove V2 docs link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@ anything for your stream.
 
 **Current APIs**
 
-| Version | Link | Sunset Date |
-| :--: | :--: | :--: |
-| 3 | [Docs](https://tiltify.github.io/api) | Active |
-| 2 | [Docs](http://info.tiltify.com/knowledgebase/articles/732651-api-documentation-campaigns-v2) | mid-2018 / TBD |
+| Version |                 Link                  | Sunset Date |
+| :-----: | :-----------------------------------: | :---------: |
+|    3    | [Docs](https://tiltify.github.io/api) |   Active    |
 
 # [Getting Started](/topics/getting-started.md)
 
 ## Issues
+
 If there is a mismatch in the documentation for the api or you have any problems, please open an issue at:
 https://github.com/tiltify/api
 
-
 ## NOTE
+
 ** DONT USE NPM IT BREAKS THINGS, USE YARN**
 
 ## Development
@@ -27,4 +27,4 @@ yarn install
 yarn start
 ```
 
-To publish to Github Pages, run ```yarn run docs:publish```
+To publish to Github Pages, run `yarn run docs:publish`

--- a/docs/topics/authentication.md
+++ b/docs/topics/authentication.md
@@ -21,6 +21,58 @@ OAuth2 Token URL
 https://tiltify.com/oauth/token
 ```
 
+## Getting A User Access Token
+
+The method to get a user access token generally follows OAuth2. The following is a specific example of how to retrieve A User Access token using OAuth2
+
+### Getting the code
+
+This example will be using the following values as needed.
+Application ID: 1234
+Redirect https://www.example.com/redirect
+Secret Key: asdf
+
+To begin with, send a user in a browser to the Tiltify OAuth Authorization url. Include your Client ID, and the response type of `code` as query parameters.
+You may include your redirect URI if you have more than one, as well as a state parameter. A space separated list of scopes may also be added, however, if not included, the `public` scope will be automatically selected.
+
+```
+https://tiltify.com/oauth/authorize?&client_id=1234&response_type=code&redirect_uri=https%3A%2F%2Fwww.example.com%2Fredirect&state=54321&scope=public
+```
+
+After signing in and authorizing, the user will be redirected back to your chosen redirect URI with a query parameter of `code`, containing the code used to fetch the access token, as well as a `state` parameter should one have been included when the user was sent to the authorization URL.
+
+```
+https://www.example.com/redirect?code=1234abcdef&state=54321
+```
+
+The code should be passed to your server backend as the following steps require your secret key, which should not be exposed to the public.
+
+### Converting The Code To A User Access Token
+
+To retrieve the User Access Token, a post request must be made to the Token URL. In the body of the url are the following fields in Form Data format. Note specifically that code is the code retrieved from the first step.
+
+```
+client_id=1234
+redirect_uri=https://www.example.com/redirect
+code=1234abcdef
+grant_type=authorization_code
+```
+
+An Authorization header must also be included following the Basic Auth standard, having a value of `Basic <base64-encoded(Application ID:Secret Key)>`. In this example case, this is `Basic MTIzNDphc2Rm`
+
+Tiltify will return a json object like the following
+
+```
+{
+   "access_token": "<the user access token>",
+   "token_type": "Bearer",
+   "scope": "public",
+   "created_at": 12345667890
+}
+```
+
+This access token may now be used as shown below to make requests. When used with the [/user](/endpoints/user.md) endpoint, the full [Users](/entities/user.md) object is returned.
+
 ## Using Access Tokens
 
 Simply add the Authorization header to your HTTP request.
@@ -40,6 +92,6 @@ Authorization: Bearer 10b56ef89e09702d4dda5860d9e5c37db0af44bcb7cb49d869be94438a
 For ease of use, we have provided an Application Access Token. This grants you
 access to the API without having to have users OAuth into your application.
 
-
 #### Cause Endpoints
+
 Some cause endpoints require additional authorization to use but will return forbidden if the access level is not granted by the used token.


### PR DESCRIPTION
Resolves #25, Resolves #28 in part.
The only thing that I would like to add would be a list of scopes and what endpoints they effect, as I do not that data, and it is implied that extra scopes are needed for some endpoints.